### PR TITLE
add note for P

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ dependencies {
 
 A package `com.kazucocoa.droidtesthelper` is example to use `com.kazucocoa.droidtesthelperlib`.
 
+# Note for Android P
+- Android P has `Restrictions on non-SDK interfaces` feature.
+    - https://developer.android.com/preview/restrictions-non-sdk-interfaces
+- `java.lang.NoSuchMethodException: setAnimationScales [class [F]` happen when we call `setAnimationScales` in animation handler
+
+- To available the interface, we need below adb commands
+    ```
+    adb shell settings put global hidden_api_policy_pre_p_apps  1
+    adb shell settings put global hidden_api_policy_p_apps 1
+    ```
+- To disable again, we need below adb commands
+    ```
+    adb shell settings delete global hidden_api_policy_pre_p_apps
+    adb shell settings delete global hidden_api_policy_p_apps
+    ```
+
+
 # load map
 
 I will add additional feature if I need.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     androidTestImplementation "com.android.support.test:runner:1.0.2"
     androidTestImplementation "com.android.support.test:rules:1.0.2"
+    androidTestImplementation "io.mockk:mockk-android:1.8.5"
 
     configurations {
         // To avoid conflict


### PR DESCRIPTION
setAnimationScales failed on Android P #32

Because it raises `Caused by: java.lang.NoSuchMethodException: setAnimationScales [class [F]`.